### PR TITLE
Updated to TeXmacs 2.1 from the main repository.

### DIFF
--- a/docs/compiling-texmacs-with-guile-3-and-qt-5-on-ubuntu-22.html
+++ b/docs/compiling-texmacs-with-guile-3-and-qt-5-on-ubuntu-22.html
@@ -32,7 +32,7 @@
     </p>
     <p>
       Guile 1.8.8 is no longer supported on modern distributions. Let us build
-      mgubi's Guile3 scheme TeXmacs fork.
+      the Guile3 scheme TeXmacs fork.
     </p>
     <h2 id="auto-2">1.<span style="margin-left: 1em"></span>Dependencies<span style="margin-left: 1em"></span></h2>
     <p>
@@ -49,22 +49,17 @@ sudo apt install libgmp-dev libltdl-dev</pre>
       in.
     </p>
     <p>
-      Clone mgubi's repo and navigate into it.
+      Clone the TeXmacs git repository and navigate into it.
     </p>
     <pre class="verbatim" xml:space="preserve">
-git clone https://github.com/mgubi/texmacs.git texmacs-guile3  </pre>
+git clone https://github.com/texmacs/texmacs.git texmacs-guile3  </pre>
     <pre class="verbatim" xml:space="preserve">
 cd  texmacs-guile3</pre>
     <p>
       Checkout the Guile 3 branch.
     </p>
     <pre class="verbatim" xml:space="preserve">
-git checkout guile3</pre>
-    <p>
-      Go into the src directory.
-    </p>
-    <pre class="verbatim" xml:space="preserve">
-cd src</pre>
+git checkout guile3_branch_2.1</pre>
     <p>
       Run the configure command (the first dashes are double dashes &ndash; it
       is just weird HTML rendering
@@ -79,31 +74,26 @@ cd src</pre>
     <pre class="verbatim" xml:space="preserve">
 make -j4</pre>
     <p>
-      It took me around 2 minutes to compile the sources with -j12. I guess
-      the scaling is nonlinear so with -j4 it should take no more than 6
-      minutes or so (just a guess).
-    </p>
-    <p>
-      The texmacs binary is placed in <tt class="verbatim">&lt;repodirectory&gt;/src/TeXmacs/bin/texmacs</tt>
+      The TeXmacs binary is placed in <tt class="verbatim">&lt;repodirectory&gt;/TeXmacs/bin/texmacs</tt>
     </p>
     <h2 id="auto-4">3.<span style="margin-left: 1em"></span>Running<span style="margin-left: 1em"></span></h2>
     <p>
-      To run texmacs you have to setup the <tt class="verbatim">TEXMACS_PATH</tt>
+      To run TeXmacs you have to setup the <tt class="verbatim">TEXMACS_PATH</tt>
       variable. Run
     </p>
     <pre class="verbatim" xml:space="preserve">
-export TEXMACS_PATH=&lt;repodirectory&gt;/src/TeXmacs</pre>
+export TEXMACS_PATH=&lt;repodirectory&gt;/TeXmacs</pre>
     <p>
       then you can run  
     </p>
     <pre class="verbatim" xml:space="preserve">
-<tt class="verbatim">&lt;repodirectory&gt;/src/TeXmacs/bin/texmacs</tt></pre>
+<tt class="verbatim">&lt;repodirectory&gt;/TeXmacs/bin/texmacs</tt></pre>
     <p>
       and TeXmacs should start after it compiled its modules. To make <tt
       class="verbatim">TEXMACS_PATH</tt> setting persistent, put the command:
     </p>
     <pre class="verbatim" xml:space="preserve">
-export TEXMACS_PATH=&lt;repodirectory&gt;/src/TeXmacs</pre>
+export TEXMACS_PATH=&lt;repodirectory&gt;/TeXmacs</pre>
     <p>
       into your <tt class="verbatim">~/.bashrc</tt>.
     </p>

--- a/src/compiling-texmacs-with-guile-3-and-qt-5-on-ubuntu-22.tm
+++ b/src/compiling-texmacs-with-guile-3-and-qt-5-on-ubuntu-22.tm
@@ -17,7 +17,7 @@
   \;
 
   Guile 1.8.8 is no longer supported on modern distributions. Let us build
-  mgubi's Guile3 scheme TeXmacs fork.
+  the Guile3 scheme TeXmacs fork.
 
   <section|Dependencies>
 
@@ -37,19 +37,16 @@
 
   Navigate to the directory where you want TeXmacs' sources to be placed in.
 
-  Clone mgubi's repo and navigate into it.
+  Clone the TeXmacs git repository and navigate into it.
 
-  <verbatim|git clone https://github.com/mgubi/texmacs.git texmacs-guile3 \ >
+  <verbatim|git clone https://github.com/texmacs/texmacs.git texmacs-guile3
+  \ >
 
   <verbatim|cd \ texmacs-guile3>
 
   Checkout the Guile 3 branch.
 
-  <verbatim|git checkout guile3>
-
-  Go into the src directory.
-
-  <verbatim|cd src>
+  <verbatim|git checkout guile3_branch_2.1>
 
   Run the configure command (the first dashes are double dashes -- it is just
   weird HTML rendering \<less\>dash\<gtr\>\<less\>dash\<gtr\>with\<less\>dash\<gtr\>guile2
@@ -61,26 +58,22 @@
 
   <verbatim|make -j4>
 
-  It took me around 2 minutes to compile the sources with -j12. I guess the
-  scaling is nonlinear so with -j4 it should take no more than 6 minutes or
-  so (just a guess).
-
-  The texmacs binary is placed in <verbatim|\<less\>repodirectory\<gtr\>/src/TeXmacs/bin/texmacs>
+  The TeXmacs binary is placed in <verbatim|\<less\>repodirectory\<gtr\>/TeXmacs/bin/texmacs>
 
   <section|Running>
 
-  To run texmacs you have to setup the <verbatim|TEXMACS_PATH> variable. Run
+  To run TeXmacs you have to setup the <verbatim|TEXMACS_PATH> variable. Run
 
-  <verbatim|export TEXMACS_PATH=\<less\>repodirectory\<gtr\>/src/TeXmacs>
+  <verbatim|export TEXMACS_PATH=\<less\>repodirectory\<gtr\>/TeXmacs>
 
   then you can run \ 
 
-  <verbatim|<verbatim|\<less\>repodirectory\<gtr\>/src/TeXmacs/bin/texmacs>>
+  <verbatim|<verbatim|\<less\>repodirectory\<gtr\>/TeXmacs/bin/texmacs>>
 
   and TeXmacs should start after it compiled its modules. To make
   <verbatim|TEXMACS_PATH> setting persistent, put the command:
 
-  <verbatim|export TEXMACS_PATH=\<less\>repodirectory\<gtr\>/src/TeXmacs>
+  <verbatim|export TEXMACS_PATH=\<less\>repodirectory\<gtr\>/TeXmacs>
 
   into your <verbatim|~/.bashrc>.
 
@@ -118,6 +111,9 @@
 
       2.<space|2spc>Compiling <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-3>
+
+      3.<space|2spc>Running <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-4>
     </associate>
   </collection>
 </auxiliary>


### PR DESCRIPTION
Uses the main guile3_branch_2.1 branch of the main repository instead of mgubi's fork.