### PR TITLE
Add links to wiki posts in community document

### DIFF
--- a/docs/community.html
+++ b/docs/community.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:x="https://www.texmacs.org/2002/extensions" xmlns:m="http://www.w3.org/1998/Math/MathML">
   <head>
     <title>TeXmacs notes</title>
-    <meta content="TeXmacs 1.99.15" name="generator"></meta>
+    <meta content="TeXmacs 1.99.19" name="generator"></meta>
     <link href="../resources/notes-base.css" type="text/css" rel="stylesheet"></link>
     <link href="../resources/blog-icon.png" rel="icon"></link>
     <script src="../resources/highlight.pack.js" language="javascript" defer></script>
@@ -31,6 +31,19 @@
     <p>
       <a href="http://forum.texmacs.cn">TeXmacs forum</a>
     </p>
+    <ul>
+      <li>
+        <p>
+          <a href="http://forum.texmacs.cn/t/undocumented-internal-macros-in-texmacs-wiki/224">Wiki post: Undocumented internal macros in TeXmacs</a>
+        </p>
+      </li>
+      <li>
+        <p>
+          <a href="http://forum.texmacs.cn/t/wiki-assorted-code-snippets-to-customize-texmacs-behaviour/465">Wiki post: Assorted code snippets to customize TeXmacs'
+          behaviour</a>
+        </p>
+      </li>
+    </ul>
     <p>
       <a href="https://gitter.im/texmacs/Lobby">TeXmacs <class style="font-variant: small-caps">Gitter</class> lobby</a>
     </p>

--- a/docs/list-articles.html
+++ b/docs/list-articles.html
@@ -25,22 +25,22 @@
       <hr></hr>
     </p>
     <p>
-      <a href="main.html">Notes on TeXmacs</a><font class="tmweb-entry-date">Thu Sep 15 13:59:24 2022
-      UTC</font>
-    </p>
-    <div class="tmweb-entry-abstract">
-      (no abstract)
-    </div>
-    <p>
-      <a href="menu-shortcuts.html">Keyboard shortcuts for menu items</a><font class="tmweb-entry-date">Thu Sep 15
-      13:55:11 2022 UTC</font>
+      <a href="menu-shortcuts.html">Keyboard shortcuts for menu items</a><font class="tmweb-entry-date">Fri Sep 23
+      11:52:19 2022 UTC</font>
     </p>
     <div class="tmweb-entry-abstract">
       How to write a keyboard shortcut for a menu item&mdash;and searching for
       text in TeXmacs <class style="font-variant: small-caps">Scheme</class> files.
     </div>
     <p>
-      <a href="list-articles.html">List of all the articles</a><font class="tmweb-entry-date">Thu Sep 15 13:55:11
+      <a href="main.html">Notes on TeXmacs</a><font class="tmweb-entry-date">Fri Sep 23 11:52:19 2022
+      UTC</font>
+    </p>
+    <div class="tmweb-entry-abstract">
+      (no abstract)
+    </div>
+    <p>
+      <a href="list-articles.html">List of all the articles</a><font class="tmweb-entry-date">Fri Sep 23 11:52:19
       2022 UTC</font>
     </p>
     <div class="tmweb-entry-abstract">
@@ -49,7 +49,7 @@
     </div>
     <p>
       <a href="compiling-texmacs-with-guile-3-and-qt-5-on-ubuntu-22.html">Compiling TeXmacs on Ubuntu 22 with Guile3 and Qt5 </a><font
-      class="tmweb-entry-date">Thu Sep 15 13:29:44 2022 UTC</font>
+      class="tmweb-entry-date">Fri Sep 16 13:23:32 2022 UTC</font>
     </p>
     <div class="tmweb-entry-abstract">
       This guide describes how to compile TeXmacs on Ubuntu 22 with Guile 3

--- a/src/community.tm
+++ b/src/community.tm
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.14>
+<TeXmacs|2.1.1>
 
 <style|notes>
 
@@ -17,6 +17,14 @@
   \;
 
   <hlink|<TeXmacs> forum|http://forum.texmacs.cn>
+
+  <\itemize>
+    <item><hlink|Wiki post: Undocumented internal macros in
+    TeXmacs|http://forum.texmacs.cn/t/undocumented-internal-macros-in-texmacs-wiki/224>
+
+    <item><hlink|Wiki post: Assorted code snippets to customize TeXmacs'
+    behaviour|http://forum.texmacs.cn/t/wiki-assorted-code-snippets-to-customize-texmacs-behaviour/465>
+  </itemize>
 
   <hlink|<TeXmacs> <name|Gitter> lobby|https://gitter.im/texmacs/Lobby>
 

--- a/src/list-articles.tm
+++ b/src/list-articles.tm
@@ -12,21 +12,21 @@
 
   <hrule>
 
-  <notes-entry|main.tm|Notes on <TeXmacs>|(no abstract)|Thu Sep 15 13:59:24
-  2022 UTC>
-
   <notes-entry|menu-shortcuts.tm|Keyboard shortcuts for menu items|How to
   write a keyboard shortcut for a menu item\Vand searching for text in
-  <TeXmacs> <scheme> files.|Thu Sep 15 13:55:11 2022 UTC>
+  <TeXmacs> <scheme> files.|Fri Sep 23 11:52:19 2022 UTC>
+
+  <notes-entry|main.tm|Notes on <TeXmacs>|(no abstract)|Fri Sep 23 11:52:19
+  2022 UTC>
 
   <notes-entry|list-articles.tm|List of all the articles|A list of all the
-  articles in the website, ordered by the most recent modification time.|Thu
-  Sep 15 13:55:11 2022 UTC>
+  articles in the website, ordered by the most recent modification time.|Fri
+  Sep 23 11:52:19 2022 UTC>
 
   <notes-entry|compiling-texmacs-with-guile-3-and-qt-5-on-ubuntu-22.tm|Compiling
   TeXmacs on Ubuntu 22 with Guile3 and Qt5 |This guide describes how to
-  compile TeXmacs on Ubuntu 22 with Guile 3 support and Qt 5.|Thu Sep 15
-  13:29:44 2022 UTC>
+  compile TeXmacs on Ubuntu 22 with Guile 3 support and Qt 5.|Fri Sep 16
+  13:23:32 2022 UTC>
 
   <notes-entry|build-using-cmake-and-mxe-on-wsl.tm|Build <TeXmacs> using
   CMake and MXE on WSL for Windows |(no abstract)|Mon Jun 28 07:01:17 2021


### PR DESCRIPTION
I added to the "community" post links to the wiki forum posts, which tend to "disappear" in the forum for logged-in users.

I restored `notes.atom` to the original state after running `update-website`. The `list-articles` has modifications whose origin I do not know, since I had reset the remote repository to the upstream one before modifying `community.tm`; on the other hand `community.html` (modified) does not have a new modification date even if it has a new one in my repository. I think I do not understand how `git` and `update-website` deal with the file modification times. 