### PR TITLE
Refine CD for gh-pages

### DIFF
--- a/.github/workflows/cd-convert-debian-bookworm.yml
+++ b/.github/workflows/cd-convert-debian-bookworm.yml
@@ -20,8 +20,14 @@ jobs:
     steps:
       - name: Install dependencies
         run: apt-get update && apt-get install -y wget git
-          
-      - uses: actions/checkout@v3
+
+      - name: Fix broken dependencies
+        run: |
+          apt-get install -y --fix-missing
+          apt-get install -f -y
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -34,12 +40,36 @@ jobs:
         run: |
           texmacs_bin=$(which texmacs)
           $texmacs_bin -headless -x '(begin (load "notes-tools.scm") (notes-update) (quit))'
-    
-      # Deploy to local repo
-      - name: Deploy
-        uses: s0/git-publish-subdir-action@develop
+
+      - name: Deploy to gh-pages
         env:
-          REPO: self
-          BRANCH: gh-pages
-          FOLDER: docs
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # set variable
+          TARGET_BRANCH="gh-pages"
+          BUILD_DIR="docs"
+          ROOT_INDEX_FILE="index.html"
+          REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          
+          # set Git config
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          
+          # init gh-pages branch
+          git clone --branch ${TARGET_BRANCH} --depth 1 ${REPO_URL} gh-pages || \
+          (git init gh-pages && cd gh-pages && git checkout --orphan ${TARGET_BRANCH})
+          cd gh-pages
+          
+          # remove old file
+          rm -rf *
+          
+          # copy 'docs' 
+          cp -r ../${BUILD_DIR}/* .
+          
+          # copy 'index.html'
+          cp ../${ROOT_INDEX_FILE} .
+          
+          # commit & push
+          git add --all
+          git commit -m "Deploy to ${TARGET_BRANCH} branch"
+          git push --force ${REPO_URL} ${TARGET_BRANCH}


### PR DESCRIPTION
Use explicit workflow instead of action from the external repo to do Continuous Deployment of HTML documents.
Also fix the issue that forget to carry over the index.html file.