### PR TITLE
fix: remove libertine-font to resolve Chinese double-quote rendering issue

### DIFF
--- a/src/notes.ts
+++ b/src/notes.ts
@@ -20,7 +20,7 @@
     </src-title>
   </active*>
 
-  <use-package|tmmanual|html-font-size|libertine-font>
+  <use-package|tmmanual|html-font-size>
 
   <\active*>
     <\src-comment>


### PR DESCRIPTION
Fixes the Chinese double-quote rendering issue reported in MoganLab/mogan#2231.

The problem was that `notes.ts` specifies `libertine-font` in the `use-package`
declaration (line 23), but Libertine doesn't have glyphs for Chinese double
quotes (""), so they fail to render in `/src/main.tm`.

The fix is straightforward — just remove `libertine-font` from the package list,
so the system falls back to a CJK-compatible font that can handle these characters.

I found this through @Tenktau's analysis in the original issue — they already
identified the root cause and suggested this exact change. I verified it matches
the code at line 23.

This is my first contribution to the texmacs/notes project. I'm working on
Mogan STEM as part of my GSoC 2026 preparation and picked this up from the
open issues. Happy to adjust anything!